### PR TITLE
allow to implement our own XmlSitemapGenerator

### DIFF
--- a/Geta.SEO.Sitemaps/Properties/AssemblyInfo.cs
+++ b/Geta.SEO.Sitemaps/Properties/AssemblyInfo.cs
@@ -12,6 +12,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("9f3a4ec0-97a5-47d5-91b2-3e60843d0ff1")]
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("1.5.2.0")]
+[assembly: AssemblyInformationalVersion("1.5.2")]
 [assembly: InternalsVisibleTo("Geta.SEO.Sitemaps.Tests")]

--- a/Geta.SEO.Sitemaps/SitemapCreateJob.cs
+++ b/Geta.SEO.Sitemaps/SitemapCreateJob.cs
@@ -3,9 +3,8 @@ using System.Linq;
 using System.Text;
 using System.Collections.Generic;
 using EPiServer;
-using EPiServer.BaseLibrary.Scheduling;
-using EPiServer.DataAbstraction;
 using EPiServer.PlugIn;
+using EPiServer.Scheduler;
 using EPiServer.ServiceLocation;
 using Geta.SEO.Sitemaps.Entities;
 using Geta.SEO.Sitemaps.Repositories;
@@ -15,7 +14,7 @@ using Geta.SEO.Sitemaps.XML;
 namespace Geta.SEO.Sitemaps
 {
     [ScheduledPlugIn(DisplayName = "Generate search engine sitemaps")]
-    public class SitemapCreateJob : JobBase
+    public class SitemapCreateJob : ScheduledJobBase
     {
         private readonly ISitemapRepository _sitemapRepository;
         private readonly SitemapXmlGeneratorFactory _sitemapXmlGeneratorFactory;


### PR DESCRIPTION
some fields converted to properties in SitemapXmlGenerator and made protected, some methods made protected so we can inherit from SitemapXmlGenerator and implement version which works in a multisite environment with global pages (pages right under the root which do not belong to any site);

fixed compiler warning (base class for a scheduled job changed);

version updated to v1.5.2;