### PR TITLE
Fixed the problem with breaking foreach loop before checking all paths…

### DIFF
--- a/src/Geta.SEO.Sitemaps/Utils/UrlFilter.cs
+++ b/src/Geta.SEO.Sitemaps/Utils/UrlFilter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Geta.SEO.Sitemaps.Entities;
 
 namespace Geta.SEO.Sitemaps.Utils
@@ -36,16 +37,15 @@ namespace Geta.SEO.Sitemaps.Utils
         {
             if (paths != null && paths.Count > 0)
             {
-                foreach (var path in paths)
+                var anyPathIsInUrl = paths.Any(x =>
                 {
-                    var dir = AddStartSlash(AddTailingSlash(path.ToLower().Trim()));
+                    var dir = AddStartSlash(AddTailingSlash(x.ToLower().Trim()));
+                    return url.ToLower().StartsWith(dir);
+                });
 
-                    var pathIsInUrl = url.ToLower().StartsWith(dir);
-
-                    if (pathIsInUrl != mustContainPath)
-                    {
-                        return true;
-                    }
+                if (anyPathIsInUrl != mustContainPath)
+                {
+                    return true;
                 }
             }
 


### PR DESCRIPTION
Fixed the problem with breaking foreach loop before checking all paths (LINQ Any extension). For now there is possible to set "Paths to include" with more than one entry separated with semicolon.