### PR TITLE
Changing dependency from class to interface

### DIFF
--- a/src/Geta.SEO.Sitemaps.Commerce/CommerceAndStandardSitemapXmlGenerator.cs
+++ b/src/Geta.SEO.Sitemaps.Commerce/CommerceAndStandardSitemapXmlGenerator.cs
@@ -21,7 +21,7 @@ namespace Geta.SEO.Sitemaps.Commerce
     [ServiceConfiguration(typeof(ICommerceAndStandardSitemapXmlGenerator))]
     public class CommerceAndStandardSitemapXmlGenerator : CommerceSitemapXmlGenerator, ICommerceAndStandardSitemapXmlGenerator
     {
-        public CommerceAndStandardSitemapXmlGenerator(ISitemapRepository sitemapRepository, IContentRepository contentRepository, UrlResolver urlResolver, SiteDefinitionRepository siteDefinitionRepository, ILanguageBranchRepository languageBranchRepository, ReferenceConverter referenceConverter, IContentFilter contentFilter)
+        public CommerceAndStandardSitemapXmlGenerator(ISitemapRepository sitemapRepository, IContentRepository contentRepository, UrlResolver urlResolver, ISiteDefinitionRepository siteDefinitionRepository, ILanguageBranchRepository languageBranchRepository, ReferenceConverter referenceConverter, IContentFilter contentFilter)
             : base(sitemapRepository, contentRepository, urlResolver, siteDefinitionRepository, languageBranchRepository, referenceConverter, contentFilter)
         {
         }

--- a/src/Geta.SEO.Sitemaps.Commerce/CommerceSitemapXmlGenerator.cs
+++ b/src/Geta.SEO.Sitemaps.Commerce/CommerceSitemapXmlGenerator.cs
@@ -25,7 +25,7 @@ namespace Geta.SEO.Sitemaps.Commerce
     {
         private readonly ReferenceConverter _referenceConverter;
 
-        public CommerceSitemapXmlGenerator(ISitemapRepository sitemapRepository, IContentRepository contentRepository, UrlResolver urlResolver, SiteDefinitionRepository siteDefinitionRepository, ILanguageBranchRepository languageBranchRepository, ReferenceConverter referenceConverter, IContentFilter contentFilter) : base(sitemapRepository, contentRepository, urlResolver, siteDefinitionRepository, languageBranchRepository, contentFilter)
+        public CommerceSitemapXmlGenerator(ISitemapRepository sitemapRepository, IContentRepository contentRepository, UrlResolver urlResolver, ISiteDefinitionRepository siteDefinitionRepository, ILanguageBranchRepository languageBranchRepository, ReferenceConverter referenceConverter, IContentFilter contentFilter) : base(sitemapRepository, contentRepository, urlResolver, siteDefinitionRepository, languageBranchRepository, contentFilter)
         {
             if (referenceConverter == null) throw new ArgumentNullException("referenceConverter");
             _referenceConverter = referenceConverter;

--- a/src/Geta.SEO.Sitemaps/XML/MobileSitemapXmlGenerator.cs
+++ b/src/Geta.SEO.Sitemaps/XML/MobileSitemapXmlGenerator.cs
@@ -13,7 +13,7 @@ namespace Geta.SEO.Sitemaps.XML
     [ServiceConfiguration(typeof(IMobileSitemapXmlGenerator))]
     public class MobileSitemapXmlGenerator : SitemapXmlGenerator, IMobileSitemapXmlGenerator
     {
-        public MobileSitemapXmlGenerator(ISitemapRepository sitemapRepository, IContentRepository contentRepository, UrlResolver urlResolver, SiteDefinitionRepository siteDefinitionRepository, ILanguageBranchRepository languageBranchRepository, IContentFilter contentFilter) : base(sitemapRepository, contentRepository, urlResolver, siteDefinitionRepository, languageBranchRepository, contentFilter)
+        public MobileSitemapXmlGenerator(ISitemapRepository sitemapRepository, IContentRepository contentRepository, UrlResolver urlResolver, ISiteDefinitionRepository siteDefinitionRepository, ILanguageBranchRepository languageBranchRepository, IContentFilter contentFilter) : base(sitemapRepository, contentRepository, urlResolver, siteDefinitionRepository, languageBranchRepository, contentFilter)
         {
         }
 

--- a/src/Geta.SEO.Sitemaps/XML/SitemapXmlGenerator.cs
+++ b/src/Geta.SEO.Sitemaps/XML/SitemapXmlGenerator.cs
@@ -35,7 +35,7 @@ namespace Geta.SEO.Sitemaps.XML
         protected readonly ISitemapRepository SitemapRepository;
         protected readonly IContentRepository ContentRepository;
         protected readonly UrlResolver UrlResolver;
-        protected readonly SiteDefinitionRepository SiteDefinitionRepository;
+        protected readonly ISiteDefinitionRepository SiteDefinitionRepository;
         protected readonly ILanguageBranchRepository LanguageBranchRepository;
         protected readonly IContentFilter ContentFilter;
         protected SitemapData SitemapData { get; set; }
@@ -55,7 +55,7 @@ namespace Geta.SEO.Sitemaps.XML
 
         public bool IsDebugMode { get; set; }
 
-        protected SitemapXmlGenerator(ISitemapRepository sitemapRepository, IContentRepository contentRepository, UrlResolver urlResolver, SiteDefinitionRepository siteDefinitionRepository, ILanguageBranchRepository languageBranchRepository,
+        protected SitemapXmlGenerator(ISitemapRepository sitemapRepository, IContentRepository contentRepository, UrlResolver urlResolver, ISiteDefinitionRepository siteDefinitionRepository, ILanguageBranchRepository languageBranchRepository,
             IContentFilter contentFilter)
         {
             this.SitemapRepository = sitemapRepository;

--- a/src/Geta.SEO.Sitemaps/XML/StandardSitemapXmlGenerator.cs
+++ b/src/Geta.SEO.Sitemaps/XML/StandardSitemapXmlGenerator.cs
@@ -11,7 +11,7 @@ namespace Geta.SEO.Sitemaps.XML
     [ServiceConfiguration(typeof(IStandardSitemapXmlGenerator))]
     public class StandardSitemapXmlGenerator : SitemapXmlGenerator, IStandardSitemapXmlGenerator
     {
-        public StandardSitemapXmlGenerator(ISitemapRepository sitemapRepository, IContentRepository contentRepository, UrlResolver urlResolver, SiteDefinitionRepository siteDefinitionRepository, ILanguageBranchRepository languageBranchRepository, IContentFilter contentFilter) : base(sitemapRepository, contentRepository, urlResolver, siteDefinitionRepository, languageBranchRepository, contentFilter)
+        public StandardSitemapXmlGenerator(ISitemapRepository sitemapRepository, IContentRepository contentRepository, UrlResolver urlResolver, ISiteDefinitionRepository siteDefinitionRepository, ILanguageBranchRepository languageBranchRepository, IContentFilter contentFilter) : base(sitemapRepository, contentRepository, urlResolver, siteDefinitionRepository, languageBranchRepository, contentFilter)
         {
         }
     }


### PR DESCRIPTION
Fixing error where SitemapXmlGenerator expected SiteDefinitionRepository, classes inheriting it in client projects in order to override methods are expected to send interface, while constructor actually expects a class.
I tried to pass the cast but it went in as null. This is tested in Byggmakker.