### PR TITLE
Use Authority property to match site's host instead of Host

### DIFF
--- a/src/Geta.SEO.Sitemaps/XML/SitemapXmlGenerator.cs
+++ b/src/Geta.SEO.Sitemaps/XML/SitemapXmlGenerator.cs
@@ -518,7 +518,7 @@ namespace Geta.SEO.Sitemaps.XML
         protected HostDefinition GetHostDefinition()
         {
             var siteUrl = new Uri(this.SitemapData.SiteUrl);
-            string sitemapHost = siteUrl.Host;
+            string sitemapHost = siteUrl.Authority;
 
             return this.SiteSettings.Hosts.FirstOrDefault(x => x.Name.Equals(sitemapHost, StringComparison.InvariantCultureIgnoreCase)) ??
                    this.SiteSettings.Hosts.FirstOrDefault(x => x.Name.Equals(SiteDefinition.WildcardHostName));


### PR DESCRIPTION
By comparing the site's host to the authority (hostname + port) one can test sitemap generation on an iisexpress site with the authority 
`localhost:_port_`
When accessing `System.Uri.Host` the hostname is all that is retrieved, so using a non-standard port for  local iis instance of the site doesn't match the hostname and port which can be stored in a HostDefinition url. Accessing `System.Uri.Authority` includes the port and allows the sitemap generator to determine which HostDefinition it's generating a sitemap for.