### PR TITLE
Include based on content type

### DIFF
--- a/src/Geta.SEO.Sitemaps/Entities/IExcludeInSitemap.cs
+++ b/src/Geta.SEO.Sitemaps/Entities/IExcludeInSitemap.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Geta.SEO.Sitemaps.Entities
+{
+    public interface IExcludeInSitemap
+    {
+    }
+}

--- a/src/Geta.SEO.Sitemaps/Entities/IIncludeInSitemap.cs
+++ b/src/Geta.SEO.Sitemaps/Entities/IIncludeInSitemap.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Geta.SEO.Sitemaps.Entities
+{
+    public interface IIncludeInSitemap
+    {
+        bool NoIndex { get; set; }
+    }
+}

--- a/src/Geta.SEO.Sitemaps/Geta.SEO.Sitemaps.csproj
+++ b/src/Geta.SEO.Sitemaps/Geta.SEO.Sitemaps.csproj
@@ -177,6 +177,8 @@
     <Compile Include="Controllers\GetaSitemapController.cs" />
     <Compile Include="CurrentLanguageContent.cs" />
     <Compile Include="Compression\QValue.cs" />
+    <Compile Include="Entities\IExcludeInSitemap.cs" />
+    <Compile Include="Entities\IIncludeInSitemap.cs" />
     <Compile Include="SitemapCreateJob.cs" />
     <Compile Include="Entities\SitemapFormat.cs" />
     <Compile Include="SpecializedProperties\PropertySEOSitemaps.cs" />

--- a/src/Geta.SEO.Sitemaps/Properties/AssemblyInfo.cs
+++ b/src/Geta.SEO.Sitemaps/Properties/AssemblyInfo.cs
@@ -12,6 +12,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("9f3a4ec0-97a5-47d5-91b2-3e60843d0ff1")]
-[assembly: AssemblyVersion("1.5.3.0")]
-[assembly: AssemblyInformationalVersion("1.5.3")]
+[assembly: AssemblyVersion("1.5.3.1")]
+[assembly: AssemblyInformationalVersion("1.5.3.1")]
 [assembly: InternalsVisibleTo("Geta.SEO.Sitemaps.Tests")]

--- a/src/Geta.SEO.Sitemaps/Utils/ContentFilter.cs
+++ b/src/Geta.SEO.Sitemaps/Utils/ContentFilter.cs
@@ -5,9 +5,10 @@ using EPiServer.Security;
 using EPiServer.ServiceLocation;
 using EPiServer.Web;
 using Geta.SEO.Sitemaps.SpecializedProperties;
+using Geta.SEO.Sitemaps.Entities;
 
 namespace Geta.SEO.Sitemaps.Utils
-{ 
+{
     [ServiceConfiguration(typeof(IContentFilter))]
     public class ContentFilter : IContentFilter
     {
@@ -16,6 +17,11 @@ namespace Geta.SEO.Sitemaps.Utils
         public virtual bool ShouldExcludeContent(IContent content)
         {
             if (content == null)
+            {
+                return true;
+            }
+
+            if(content is IExcludeInSitemap)
             {
                 return true;
             }
@@ -44,6 +50,11 @@ namespace Geta.SEO.Sitemaps.Utils
                 return true;
             }
 
+            if (content is IIncludeInSitemap && IsNoIndexSet(content))
+            {
+                return true;
+            }
+
             if (!IsVisibleOnSite(content))
             {
                 return true;
@@ -67,6 +78,12 @@ namespace Geta.SEO.Sitemaps.Utils
             }
 
             return false;
+        }
+
+        private bool IsNoIndexSet(IContent content)
+        {
+            var includeInSitemap = (IIncludeInSitemap)content;
+            return includeInSitemap.NoIndex;
         }
 
         private static bool IsVisibleOnSite(IContent content)

--- a/test/Geta.SEO.Sitemaps.Tests/ContentFilterTest.cs
+++ b/test/Geta.SEO.Sitemaps.Tests/ContentFilterTest.cs
@@ -1,0 +1,130 @@
+﻿namespace Tests
+{
+    using EPiServer.Core;
+    using EPiServer.Framework.Web;
+    using EPiServer.Security;
+    using EPiServer.ServiceLocation;
+    using EPiServer.Web;
+    using Geta.SEO.Sitemaps.Entities;
+    using Geta.SEO.Sitemaps.SpecializedProperties;
+    using Geta.SEO.Sitemaps.Utils;
+    using NSubstitute;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Principal;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public class ContentFilterTest
+    {
+        [Fact]
+        public void DontAddPagesWithContentTypeImplementingIExcludeInSitemap()
+        {
+            // Arrange
+            var content = Substitute.For<IContent, IExcludeInSitemap>();
+            var filter = new ContentFilter();
+            // Act
+            var result = filter.ShouldExcludeContent(content);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void AddPagesWithContentTypeDontImplementingIExcludeInSitemap()
+        {
+            // Arrange
+            PageData content = CreatePageToBeIncludedInSitemap();
+
+            var filter = new ContentFilter();
+
+            // Act
+            var result = filter.ShouldExcludeContent(content);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void DontAddPagesWithContentTypeImplementingIIncludeInSitemapAndNoIndex()
+        {
+            // Arrange
+            PageData content = CreatePageWithNoIndexNotToBeIncludedInSitemap();
+
+            var filter = new ContentFilter();
+
+            // Act
+            var result = filter.ShouldExcludeContent(content);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        private PageData CreatePageWithNoIndexNotToBeIncludedInSitemap()
+        {
+            var content = Substitute.For<PageData, IIncludeInSitemap>();
+            var visitorPrinciple = new GenericPrincipal(
+                new GenericIdentity("visitor"),
+                new[] { "Everyone" });
+
+            content.GetSecurityDescriptor().HasAccess(visitorPrinciple, AccessLevel.Read).ReturnsForAnyArgs(true);
+
+            ((IIncludeInSitemap)content).NoIndex = true;
+            content.Status = VersionStatus.Published;
+            var propCollection = new PropertyDataCollection
+            {
+                { PropertySEOSitemaps.PropertyName, new PropertySEOSitemaps() { Enabled = true } }
+            };
+            content.Property.Returns(propCollection);
+
+            // Create a mock service locator
+            var mockLocator = Substitute.For<IServiceLocator>();
+            var mockTemplateResolver = Substitute.For<TemplateResolver>();
+            mockTemplateResolver.HasTemplate(content, TemplateTypeCategories.Page).ReturnsForAnyArgs(true);
+
+            // Setup the service locator to return our mock repository when an IContentRepository is requested
+            mockLocator.GetInstance<TemplateResolver>().Returns(mockTemplateResolver);
+
+            // Make use of our mock objects throughout EPiServer
+            ServiceLocator.SetLocator(mockLocator);
+
+            var startPageRef = new ContentReference(2);
+            content.ContentLink.Returns(startPageRef);
+            return content;
+        }
+
+        private static PageData CreatePageToBeIncludedInSitemap()
+        {
+            var content = Substitute.For<PageData>();
+            var visitorPrinciple = new GenericPrincipal(
+                new GenericIdentity("visitor"),
+                new[] { "Everyone" });
+
+            content.GetSecurityDescriptor().HasAccess(visitorPrinciple, AccessLevel.Read).ReturnsForAnyArgs(true);
+
+            content.Status = VersionStatus.Published;
+            var propCollection = new PropertyDataCollection
+            {
+                { PropertySEOSitemaps.PropertyName, new PropertySEOSitemaps() { Enabled = true } }
+            };
+            content.Property.Returns(propCollection);
+
+            // Create a mock service locator
+            var mockLocator = Substitute.For<IServiceLocator>();
+            var mockTemplateResolver = Substitute.For<TemplateResolver>();
+            mockTemplateResolver.HasTemplate(content, TemplateTypeCategories.Page).ReturnsForAnyArgs(true);
+
+            // Setup the service locator to return our mock repository when an IContentRepository is requested
+            mockLocator.GetInstance<TemplateResolver>().Returns(mockTemplateResolver);
+
+            // Make use of our mock objects throughout EPiServer
+            ServiceLocator.SetLocator(mockLocator);
+
+            var startPageRef = new ContentReference(2);
+            content.ContentLink.Returns(startPageRef);
+            return content;
+        }
+    }
+}

--- a/test/Geta.SEO.Sitemaps.Tests/ContentFilterTest.cs
+++ b/test/Geta.SEO.Sitemaps.Tests/ContentFilterTest.cs
@@ -9,12 +9,7 @@
     using Geta.SEO.Sitemaps.SpecializedProperties;
     using Geta.SEO.Sitemaps.Utils;
     using NSubstitute;
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using System.Security.Principal;
-    using System.Text;
-    using System.Threading.Tasks;
     using Xunit;
 
     public class ContentFilterTest
@@ -78,16 +73,11 @@
                 { PropertySEOSitemaps.PropertyName, new PropertySEOSitemaps() { Enabled = true } }
             };
             content.Property.Returns(propCollection);
-
-            // Create a mock service locator
+            
             var mockLocator = Substitute.For<IServiceLocator>();
             var mockTemplateResolver = Substitute.For<TemplateResolver>();
             mockTemplateResolver.HasTemplate(content, TemplateTypeCategories.Page).ReturnsForAnyArgs(true);
-
-            // Setup the service locator to return our mock repository when an IContentRepository is requested
             mockLocator.GetInstance<TemplateResolver>().Returns(mockTemplateResolver);
-
-            // Make use of our mock objects throughout EPiServer
             ServiceLocator.SetLocator(mockLocator);
 
             var startPageRef = new ContentReference(2);
@@ -110,16 +100,11 @@
                 { PropertySEOSitemaps.PropertyName, new PropertySEOSitemaps() { Enabled = true } }
             };
             content.Property.Returns(propCollection);
-
-            // Create a mock service locator
+            
             var mockLocator = Substitute.For<IServiceLocator>();
             var mockTemplateResolver = Substitute.For<TemplateResolver>();
-            mockTemplateResolver.HasTemplate(content, TemplateTypeCategories.Page).ReturnsForAnyArgs(true);
-
-            // Setup the service locator to return our mock repository when an IContentRepository is requested
+            mockTemplateResolver.HasTemplate(content, TemplateTypeCategories.Page).ReturnsForAnyArgs(true);            
             mockLocator.GetInstance<TemplateResolver>().Returns(mockTemplateResolver);
-
-            // Make use of our mock objects throughout EPiServer
             ServiceLocator.SetLocator(mockLocator);
 
             var startPageRef = new ContentReference(2);

--- a/test/Geta.SEO.Sitemaps.Tests/Geta.SEO.Sitemaps.Tests.csproj
+++ b/test/Geta.SEO.Sitemaps.Tests/Geta.SEO.Sitemaps.Tests.csproj
@@ -163,6 +163,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ContentFilterTest.cs" />
     <Compile Include="GetaSitemapControllerTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="CompressionHandlerTest.cs" />


### PR DESCRIPTION
Pages of some content types should not be included in the sitemap. These can be for example NewsContainer pages that just structure the page tree to be a little more organized. These pages should not included.
I've included to interfaces, IIncludeInSitemap and IExcludeInSitemap.
Add IExcludeInSitemap to those content types that one wish to exclude from Sitemap
Add IExcludeInSitemap to those content types that you wish to control both if page should be included in Sitemap and has a <meta name="robots" content="noindex"> added to them.
Hopefully these minor changes can be useful to others, they fit our SEO workflow nicely.
Has added test to cover added functionallity to ContentFilter.cs