### PR TITLE
Use InvariantCulture for writing "lastmod" value

### DIFF
--- a/src/Geta.SEO.Sitemaps/XML/SitemapXmlGenerator.cs
+++ b/src/Geta.SEO.Sitemaps/XML/SitemapXmlGenerator.cs
@@ -328,7 +328,7 @@ namespace Geta.SEO.Sitemaps.XML
             var element = new XElement(
                 SitemapXmlNamespace + "url",
                 new XElement(SitemapXmlNamespace + "loc", url),
-                new XElement(SitemapXmlNamespace + "lastmod", modified.ToString(DateTimeFormat)),
+                new XElement(SitemapXmlNamespace + "lastmod", modified.ToString(DateTimeFormat, CultureInfo.InvariantCulture)),
                 new XElement(SitemapXmlNamespace + "changefreq", (property != null) ? property.ChangeFreq : "weekly"),
                 new XElement(SitemapXmlNamespace + "priority", (property != null) ? property.Priority : GetPriority(url))
             );


### PR DESCRIPTION
Use InvariantCulture when writing lastmod to avoid current culture causing invalid sitemap datetime formatting regardless of DateTimeFormat constant value. For example, running on server with Finnish culture would format datetime as e.g. "2018-02-08T09.06.10+02:00".