### PR TITLE
Upgrade to Episerver Commerce 12

### DIFF
--- a/src/Geta.SEO.Sitemaps.Commerce/Geta.SEO.Sitemaps.Commerce.csproj
+++ b/src/Geta.SEO.Sitemaps.Commerce/Geta.SEO.Sitemaps.Commerce.csproj
@@ -104,10 +104,9 @@
       <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.2.1\lib\net461\EPiServer.Web.WebControls.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
-    <Reference Include="Lucene.Net">
+    <Reference Include="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>
     </Reference>
     <Reference Include="Mediachase.BusinessFoundation, Version=11.5.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
@@ -159,7 +158,6 @@
       <HintPath>..\..\packages\EPiServer.Commerce.Core.11.5.0\lib\net461\Mediachase.WebConsoleLib.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
       <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -197,7 +195,6 @@
     </Reference>
     <Reference Include="System.Threading.Tasks.Dataflow, Version=4.5.24.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System.Transactions" />
     <Reference Include="System.Web" />

--- a/src/Geta.SEO.Sitemaps.Commerce/Geta.SEO.Sitemaps.Commerce.csproj
+++ b/src/Geta.SEO.Sitemaps.Commerce/Geta.SEO.Sitemaps.Commerce.csproj
@@ -103,9 +103,6 @@
     <Reference Include="EPiServer.Web.WebControls, Version=11.2.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.2.1\lib\net461\EPiServer.Web.WebControls.dll</HintPath>
     </Reference>
-    <Reference Include="Geta.SEO.Sitemaps, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Geta.SEO.Sitemaps.2.0.1\lib\net461\Geta.SEO.Sitemaps.dll</HintPath>
-    </Reference>
     <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
@@ -237,6 +234,12 @@
   <ItemGroup>
     <None Include="Geta.SEO.Sitemaps.Commerce.nuspec" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Geta.SEO.Sitemaps\Geta.SEO.Sitemaps.csproj">
+      <Project>{e1c27292-1731-4c8c-a305-80e084d8ee3d}</Project>
+      <Name>Geta.SEO.Sitemaps</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Geta.SEO.Sitemaps.Commerce/Geta.SEO.Sitemaps.Commerce.csproj
+++ b/src/Geta.SEO.Sitemaps.Commerce/Geta.SEO.Sitemaps.Commerce.csproj
@@ -31,8 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AjaxControlToolkit, Version=3.0.30930.28736, Culture=neutral, PublicKeyToken=28f01b0e84b6d53e, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.11.5.0\lib\net461\AjaxControlToolkit.dll</HintPath>
+    <Reference Include="AjaxControlToolkit, Version=3.0.30930.28736, Culture=neutral, PublicKeyToken=28f01b0e84b6d53e">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\AjaxControlToolkit.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="AuthorizeNet, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\AuthorizeNet.1.9.4\lib\AuthorizeNet.dll</HintPath>
@@ -43,53 +44,68 @@
     <Reference Include="Castle.Windsor, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Castle.Windsor.4.1.0\lib\net45\Castle.Windsor.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer, Version=11.2.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.Core.11.2.1\lib\net461\EPiServer.dll</HintPath>
+    <Reference Include="EPiServer, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.CMS.Core.11.4.0\lib\net461\EPiServer.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.ApplicationModules, Version=11.2.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.2.1\lib\net461\EPiServer.ApplicationModules.dll</HintPath>
+    <Reference Include="EPiServer.ApplicationModules, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.ApplicationModules.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.Business.Commerce, Version=11.5.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.11.5.0\lib\net461\EPiServer.Business.Commerce.dll</HintPath>
+    <Reference Include="EPiServer.Business.Commerce, Version=12.0.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\EPiServer.Business.Commerce.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.Cms.AspNet, Version=11.2.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.2.1\lib\net461\EPiServer.Cms.AspNet.dll</HintPath>
+    <Reference Include="EPiServer.Cms.AspNet, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.4.0\lib\net461\EPiServer.Cms.AspNet.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="EPiServer.Cms.Shell.UI, Version=11.1.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EPiServer.CMS.UI.Core.11.1.0\lib\net461\EPiServer.Cms.Shell.UI.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Commerce.Internal.Migration, Version=11.5.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.11.5.0\lib\net461\EPiServer.Commerce.Internal.Migration.dll</HintPath>
+    <Reference Include="EPiServer.Commerce.Internal.Migration, Version=12.0.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\EPiServer.Commerce.Internal.Migration.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.Configuration, Version=11.2.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.2.1\lib\net461\EPiServer.Configuration.dll</HintPath>
+    <Reference Include="EPiServer.Configuration, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.4.0\lib\net461\EPiServer.Configuration.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.Data, Version=11.2.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.2.1\lib\net461\EPiServer.Data.dll</HintPath>
+    <Reference Include="EPiServer.Data, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.Data.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.Data.Cache, Version=11.2.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.2.1\lib\net461\EPiServer.Data.Cache.dll</HintPath>
+    <Reference Include="EPiServer.Data.Cache, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.Data.Cache.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.Enterprise, Version=11.2.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.Core.11.2.1\lib\net461\EPiServer.Enterprise.dll</HintPath>
+    <Reference Include="EPiServer.Enterprise, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.CMS.Core.11.4.0\lib\net461\EPiServer.Enterprise.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.Events, Version=11.2.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.2.1\lib\net461\EPiServer.Events.dll</HintPath>
+    <Reference Include="EPiServer.Events, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.Events.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.Framework, Version=11.2.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.2.1\lib\net461\EPiServer.Framework.dll</HintPath>
+    <Reference Include="EPiServer.Framework, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.Framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.Framework.AspNet, Version=11.2.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.AspNet.11.2.1\lib\net461\EPiServer.Framework.AspNet.dll</HintPath>
+    <Reference Include="EPiServer.Framework.AspNet, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.Framework.AspNet.11.4.0\lib\net461\EPiServer.Framework.AspNet.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.ImageLibrary, Version=11.2.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.2.1\lib\net461\EPiServer.ImageLibrary.dll</HintPath>
+    <Reference Include="EPiServer.ImageLibrary, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.4.0\lib\net461\EPiServer.ImageLibrary.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.Licensing, Version=11.2.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.2.1\lib\net461\EPiServer.Licensing.dll</HintPath>
+    <Reference Include="EPiServer.Licensing, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.Licensing.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.LinkAnalyzer, Version=11.2.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.Core.11.2.1\lib\net461\EPiServer.LinkAnalyzer.dll</HintPath>
+    <Reference Include="EPiServer.LinkAnalyzer, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.CMS.Core.11.4.0\lib\net461\EPiServer.LinkAnalyzer.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="EPiServer.Shell, Version=11.1.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EPiServer.CMS.UI.Core.11.1.0\lib\net461\EPiServer.Shell.dll</HintPath>
@@ -100,8 +116,9 @@
     <Reference Include="EPiServer.UI, Version=11.1.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EPiServer.CMS.UI.Core.11.1.0\lib\net461\EPiServer.UI.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Web.WebControls, Version=11.2.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.2.1\lib\net461\EPiServer.Web.WebControls.dll</HintPath>
+    <Reference Include="EPiServer.Web.WebControls, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.4.0\lib\net461\EPiServer.Web.WebControls.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
       <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
@@ -109,53 +126,69 @@
     <Reference Include="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.BusinessFoundation, Version=11.5.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.11.5.0\lib\net461\Mediachase.BusinessFoundation.dll</HintPath>
+    <Reference Include="Mediachase.BusinessFoundation, Version=12.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.BusinessFoundation.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Mediachase.BusinessFoundation.Data, Version=11.5.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.11.5.0\lib\net461\Mediachase.BusinessFoundation.Data.dll</HintPath>
+    <Reference Include="Mediachase.BusinessFoundation.Data, Version=12.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.BusinessFoundation.Data.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Mediachase.Commerce, Version=11.5.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.11.5.0\lib\net461\Mediachase.Commerce.dll</HintPath>
+    <Reference Include="Mediachase.Commerce, Version=12.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Commerce.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Mediachase.Commerce.Marketing.Validators, Version=11.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.11.5.0\lib\net461\Mediachase.Commerce.Marketing.Validators.dll</HintPath>
+    <Reference Include="Mediachase.Commerce.Marketing.Validators, Version=12.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Commerce.Marketing.Validators.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Mediachase.Commerce.Plugins.Payment, Version=11.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.11.5.0\lib\net461\Mediachase.Commerce.Plugins.Payment.dll</HintPath>
+    <Reference Include="Mediachase.Commerce.Plugins.Payment, Version=12.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Commerce.Plugins.Payment.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Mediachase.Commerce.Plugins.Shipping, Version=11.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.11.5.0\lib\net461\Mediachase.Commerce.Plugins.Shipping.dll</HintPath>
+    <Reference Include="Mediachase.Commerce.Plugins.Shipping, Version=12.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Commerce.Plugins.Shipping.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Mediachase.Commerce.Website, Version=11.5.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.11.5.0\lib\net461\Mediachase.Commerce.Website.dll</HintPath>
+    <Reference Include="Mediachase.Commerce.Website, Version=12.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Commerce.Website.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Mediachase.Commerce.Workflow, Version=11.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.11.5.0\lib\net461\Mediachase.Commerce.Workflow.dll</HintPath>
+    <Reference Include="Mediachase.Commerce.Workflow, Version=12.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Commerce.Workflow.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Mediachase.DataProvider, Version=11.5.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.11.5.0\lib\net461\Mediachase.DataProvider.dll</HintPath>
+    <Reference Include="Mediachase.DataProvider, Version=12.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.DataProvider.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Mediachase.FileUploader, Version=11.5.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.11.5.0\lib\net461\Mediachase.FileUploader.dll</HintPath>
+    <Reference Include="Mediachase.FileUploader, Version=12.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.FileUploader.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Mediachase.MetaDataPlus, Version=11.5.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.11.5.0\lib\net461\Mediachase.MetaDataPlus.dll</HintPath>
+    <Reference Include="Mediachase.MetaDataPlus, Version=12.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.MetaDataPlus.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Mediachase.Search, Version=11.5.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.11.5.0\lib\net461\Mediachase.Search.dll</HintPath>
+    <Reference Include="Mediachase.Search, Version=12.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Search.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Mediachase.Search.Extensions, Version=11.5.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.11.5.0\lib\net461\Mediachase.Search.Extensions.dll</HintPath>
+    <Reference Include="Mediachase.Search.Extensions, Version=12.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Search.Extensions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Mediachase.Search.LuceneSearchProvider, Version=11.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.11.5.0\lib\net461\Mediachase.Search.LuceneSearchProvider.dll</HintPath>
+    <Reference Include="Mediachase.Search.LuceneSearchProvider, Version=12.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Search.LuceneSearchProvider.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Mediachase.SqlDataProvider, Version=11.5.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.11.5.0\lib\net461\Mediachase.SqlDataProvider.dll</HintPath>
+    <Reference Include="Mediachase.SqlDataProvider, Version=12.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.SqlDataProvider.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Mediachase.WebConsoleLib, Version=11.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.11.5.0\lib\net461\Mediachase.WebConsoleLib.dll</HintPath>
+    <Reference Include="Mediachase.WebConsoleLib, Version=12.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.WebConsoleLib.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>

--- a/src/Geta.SEO.Sitemaps.Commerce/Geta.SEO.Sitemaps.Commerce.nuspec
+++ b/src/Geta.SEO.Sitemaps.Commerce/Geta.SEO.Sitemaps.Commerce.nuspec
@@ -11,9 +11,5 @@
     <tags>Sitemap SEO EPiServer Commerce</tags>
     <projectUrl>https://github.com/Geta/SEO.Sitemaps/</projectUrl>
     <iconUrl>http://cdn.geta.no/opensource/icons/geta-sitemaps-icon.png</iconUrl>
-  <dependencies>
-      <dependency id="Geta.SEO.Sitemaps" version="[2.0.1, 3.0)" />
-      <dependency id="EPiServer.Commerce.Core" version="[11.5.0, 12.0)" />
-    </dependencies> 
   </metadata>
 </package>

--- a/src/Geta.SEO.Sitemaps.Commerce/packages.config
+++ b/src/Geta.SEO.Sitemaps.Commerce/packages.config
@@ -10,7 +10,6 @@
   <package id="EPiServer.Commerce.Core" version="11.5.0" targetFramework="net461" />
   <package id="EPiServer.Framework" version="11.2.1" targetFramework="net461" />
   <package id="EPiServer.Framework.AspNet" version="11.2.1" targetFramework="net461" />
-  <package id="Geta.SEO.Sitemaps" version="2.0.1" targetFramework="net461" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net461" />

--- a/src/Geta.SEO.Sitemaps.Commerce/packages.config
+++ b/src/Geta.SEO.Sitemaps.Commerce/packages.config
@@ -3,13 +3,13 @@
   <package id="AuthorizeNet" version="1.9.4" targetFramework="net461" />
   <package id="Castle.Core" version="4.2.1" targetFramework="net461" />
   <package id="Castle.Windsor" version="4.1.0" targetFramework="net461" />
-  <package id="EPiServer.CMS.AspNet" version="11.2.1" targetFramework="net461" />
-  <package id="EPiServer.CMS.Core" version="11.2.1" targetFramework="net461" />
+  <package id="EPiServer.CMS.AspNet" version="11.4.0" targetFramework="net461" />
+  <package id="EPiServer.CMS.Core" version="11.4.0" targetFramework="net461" />
   <package id="EPiServer.CMS.UI" version="11.1.0" targetFramework="net461" />
   <package id="EPiServer.CMS.UI.Core" version="11.1.0" targetFramework="net461" />
-  <package id="EPiServer.Commerce.Core" version="11.5.0" allowedVersions="[11.5.0,12)" targetFramework="net461" />
-  <package id="EPiServer.Framework" version="11.2.1" targetFramework="net461" />
-  <package id="EPiServer.Framework.AspNet" version="11.2.1" targetFramework="net461" />
+  <package id="EPiServer.Commerce.Core" version="12.0.0" allowedVersions="[12.0.0,13)" targetFramework="net461" />
+  <package id="EPiServer.Framework" version="11.4.0" targetFramework="net461" />
+  <package id="EPiServer.Framework.AspNet" version="11.4.0" targetFramework="net461" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net461" />

--- a/src/Geta.SEO.Sitemaps.Commerce/packages.config
+++ b/src/Geta.SEO.Sitemaps.Commerce/packages.config
@@ -10,14 +10,14 @@
   <package id="EPiServer.Commerce.Core" version="11.5.0" allowedVersions="[11.5.0,12)" targetFramework="net461" />
   <package id="EPiServer.Framework" version="11.2.1" targetFramework="net461" />
   <package id="EPiServer.Framework.AspNet" version="11.2.1" targetFramework="net461" />
-  <package id="Lucene.Net" version="3.0.3" targetFramework="net45" />
+  <package id="Lucene.Net" version="3.0.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net461" />
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net461" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
-  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net461" />
   <package id="System.ComponentModel.Annotations" version="4.4.0" targetFramework="net461" />
   <package id="System.Data.SqlClient" version="4.4.0" targetFramework="net461" />
   <package id="System.Reflection.Emit" version="4.3.0" targetFramework="net461" />

--- a/src/Geta.SEO.Sitemaps.Commerce/packages.config
+++ b/src/Geta.SEO.Sitemaps.Commerce/packages.config
@@ -7,7 +7,7 @@
   <package id="EPiServer.CMS.Core" version="11.2.1" targetFramework="net461" />
   <package id="EPiServer.CMS.UI" version="11.1.0" targetFramework="net461" />
   <package id="EPiServer.CMS.UI.Core" version="11.1.0" targetFramework="net461" />
-  <package id="EPiServer.Commerce.Core" version="11.5.0" targetFramework="net461" />
+  <package id="EPiServer.Commerce.Core" version="11.5.0" allowedVersions="[11.5.0,12)" targetFramework="net461" />
   <package id="EPiServer.Framework" version="11.2.1" targetFramework="net461" />
   <package id="EPiServer.Framework.AspNet" version="11.2.1" targetFramework="net461" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net45" />

--- a/src/Geta.SEO.Sitemaps/Geta.SEO.Sitemaps.csproj
+++ b/src/Geta.SEO.Sitemaps/Geta.SEO.Sitemaps.csproj
@@ -105,7 +105,6 @@
       <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.2.1\lib\net461\EPiServer.Web.WebControls.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
       <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -143,7 +142,6 @@
     </Reference>
     <Reference Include="System.Threading.Tasks.Dataflow, Version=4.5.24.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System.Transactions" />
     <Reference Include="System.Web" />
@@ -214,9 +212,7 @@
     <None Include="Geta.SEO.Sitemaps.nuspec">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Modules\Geta.SEO.Sitemaps\AdminManageSitemap.aspx">

--- a/src/Geta.SEO.Sitemaps/Geta.SEO.Sitemaps.nuspec
+++ b/src/Geta.SEO.Sitemaps/Geta.SEO.Sitemaps.nuspec
@@ -11,10 +11,6 @@
     <tags>Sitemap SEO EPiServer</tags>
     <projectUrl>https://github.com/Geta/SEO.Sitemaps/</projectUrl>
     <iconUrl>http://cdn.geta.no/opensource/icons/geta-sitemaps-icon.png</iconUrl>
-    <dependencies>
-      <dependency id="EPiServer.CMS.UI" version="[11.1.0, 12.0)" />
-      <dependency id="EPiServer.CMS.Core" version="[11.2.1, 12.0)" />
-    </dependencies>
   </metadata>
   <files>
     <file src="Modules\Geta.SEO.Sitemaps\AdminManageSitemap.aspx" target="content\modules\Geta.SEO.Sitemaps\AdminManageSitemap.aspx" />

--- a/src/Geta.SEO.Sitemaps/packages.config
+++ b/src/Geta.SEO.Sitemaps/packages.config
@@ -3,8 +3,8 @@
   <package id="Castle.Core" version="4.2.1" targetFramework="net461" />
   <package id="Castle.Windsor" version="4.1.0" targetFramework="net461" />
   <package id="EPiServer.CMS.AspNet" version="11.2.1" targetFramework="net461" />
-  <package id="EPiServer.CMS.Core" version="11.2.1" targetFramework="net461" />
-  <package id="EPiServer.CMS.UI" version="11.1.0" targetFramework="net461" />
+  <package id="EPiServer.CMS.Core" version="11.2.1" allowedVersions="[11.2.1,12)" targetFramework="net461" />
+  <package id="EPiServer.CMS.UI" version="11.1.0" allowedVersions="[11.1.0,12)" targetFramework="net461" />
   <package id="EPiServer.CMS.UI.Core" version="11.1.0" targetFramework="net461" />
   <package id="EPiServer.Framework" version="11.2.1" targetFramework="net461" />
   <package id="EPiServer.Framework.AspNet" version="11.2.1" targetFramework="net461" />

--- a/src/Geta.SEO.Sitemaps/packages.config
+++ b/src/Geta.SEO.Sitemaps/packages.config
@@ -12,7 +12,7 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net461" />
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net461" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="System.ComponentModel.Annotations" version="4.4.0" targetFramework="net461" />
   <package id="System.Data.SqlClient" version="4.4.0" targetFramework="net461" />

--- a/test/Geta.SEO.Sitemaps.Tests/Geta.SEO.Sitemaps.Tests.csproj
+++ b/test/Geta.SEO.Sitemaps.Tests/Geta.SEO.Sitemaps.Tests.csproj
@@ -16,6 +16,8 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <TestProjectType>Test</TestProjectType>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -70,26 +72,21 @@
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NSubstitute.1.10.0.0\lib\net45\NSubstitute.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="StructureMap, Version=3.1.6.186, Culture=neutral, PublicKeyToken=e60ad81abae3c223, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\structuremap-signed.3.1.6.186\lib\net40\StructureMap.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="StructureMap, Version=3.1.6.191, Culture=neutral, PublicKeyToken=e60ad81abae3c223, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\structuremap-signed.3.1.6.191\lib\net40\StructureMap.dll</HintPath>
     </Reference>
-    <Reference Include="StructureMap.Net4, Version=3.1.6.186, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\structuremap-signed.3.1.6.186\lib\net40\StructureMap.Net4.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="StructureMap.Net4, Version=3.1.6.191, Culture=neutral, PublicKeyToken=e60ad81abae3c223, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\structuremap-signed.3.1.6.191\lib\net40\StructureMap.Net4.dll</HintPath>
     </Reference>
     <Reference Include="StructureMap.Web, Version=1.0.0.0, Culture=neutral, PublicKeyToken=e60ad81abae3c223, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\structuremap.web-signed.3.1.6.186\lib\net40\StructureMap.Web.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\structuremap.web-signed.3.1.6.191\lib\net40\StructureMap.Web.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Annotations, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -123,7 +120,6 @@
     </Reference>
     <Reference Include="System.Threading.Tasks.Dataflow, Version=4.5.24.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System.Transactions" />
     <Reference Include="System.Web" />
@@ -148,19 +144,15 @@
     <Reference Include="System.Xml" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
-      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -169,15 +161,13 @@
     <Compile Include="CompressionHandlerTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Geta.SEO.Sitemaps\Geta.SEO.Sitemaps.csproj">
       <Project>{E1C27292-1731-4C8C-A305-80E084D8EE3D}</Project>
       <Name>Geta.SEO.Sitemaps</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/test/Geta.SEO.Sitemaps.Tests/packages.config
+++ b/test/Geta.SEO.Sitemaps.Tests/packages.config
@@ -8,11 +8,11 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net461" />
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net461" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
-  <package id="NSubstitute" version="1.10.0.0" targetFramework="net452" />
-  <package id="structuremap.web-signed" version="3.1.6.186" targetFramework="net45" />
-  <package id="structuremap-signed" version="3.1.6.186" targetFramework="net45" />
+  <package id="NSubstitute" version="1.10.0.0" targetFramework="net461" />
+  <package id="structuremap.web-signed" version="3.1.6.191" targetFramework="net461" />
+  <package id="structuremap-signed" version="3.1.6.191" targetFramework="net461" />
   <package id="System.ComponentModel.Annotations" version="4.4.0" targetFramework="net461" />
   <package id="System.Data.SqlClient" version="4.4.0" targetFramework="net461" />
   <package id="System.Reflection.Emit" version="4.3.0" targetFramework="net461" />
@@ -21,12 +21,12 @@
   <package id="System.Security.Permissions" version="4.4.0" targetFramework="net461" />
   <package id="System.Security.Principal.Windows" version="4.4.0" targetFramework="net461" />
   <package id="System.Threading.AccessControl" version="4.4.0" targetFramework="net461" />
-  <package id="xunit" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.core" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.runner.console" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net452" />
+  <package id="xunit" version="2.1.0" targetFramework="net461" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net461" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net461" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net461" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net461" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net461" />
+  <package id="xunit.runner.console" version="2.1.0" targetFramework="net461" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
This also includes:
- fix for internal references
- moved dependant package version restrictions to the packages.config to get rid of duplication
- reinstalled packages to fix framework version differences