### PR TITLE
Skip all pagetypes that implement the IExcludeFromSitemap interface

### DIFF
--- a/src/Geta.SEO.Sitemaps/Geta.SEO.Sitemaps.csproj
+++ b/src/Geta.SEO.Sitemaps/Geta.SEO.Sitemaps.csproj
@@ -182,6 +182,7 @@
     <Compile Include="CurrentLanguageContent.cs" />
     <Compile Include="Compression\QValue.cs" />
     <Compile Include="EditorDescriptors\SeoSitemapEditorDescriptor.cs" />
+    <Compile Include="Models\IExcludeFromSitemap.cs" />
     <Compile Include="module\Views\AdminManageSitemap.aspx.cs">
       <DependentUpon>AdminManageSitemap.aspx</DependentUpon>
       <SubType>ASPXCodeBehind</SubType>

--- a/src/Geta.SEO.Sitemaps/Models/IExcludeFromSitemap.cs
+++ b/src/Geta.SEO.Sitemaps/Models/IExcludeFromSitemap.cs
@@ -1,0 +1,11 @@
+﻿using EPiServer.Core;
+
+namespace Geta.SEO.Sitemaps.Models
+{
+    /// <summary>
+    /// Apply this interface to pagetypes you do not want to include in the index
+    /// </summary>
+    public interface IExcludeFromSitemap : IContent
+    {
+    }
+}

--- a/src/Geta.SEO.Sitemaps/XML/SitemapXmlGenerator.cs
+++ b/src/Geta.SEO.Sitemaps/XML/SitemapXmlGenerator.cs
@@ -19,6 +19,7 @@ using EPiServer.Logging.Compatibility;
 using EPiServer.Web;
 using EPiServer.Web.Routing;
 using Geta.SEO.Sitemaps.Entities;
+using Geta.SEO.Sitemaps.Models;
 using Geta.SEO.Sitemaps.Repositories;
 using Geta.SEO.Sitemaps.SpecializedProperties;
 using Geta.SEO.Sitemaps.Utils;
@@ -178,6 +179,11 @@ namespace Geta.SEO.Sitemaps.XML
                 if (StopGeneration)
                 {
                     return Enumerable.Empty<XElement>();
+                }
+
+                if (this.ContentRepository.TryGet<IExcludeFromSitemap>(contentReference, out _))
+                {
+                    continue;
                 }
 
                 var contentLanguages = this.GetLanguageBranches(contentReference);


### PR DESCRIPTION
This allows you to add this interface to a new or existing Episerver content type to exclude the given content type from the sitemap index